### PR TITLE
feat: 新增分頁功能，搜尋結果從 5 筆增至 10 筆

### DIFF
--- a/integrations/google/api.py
+++ b/integrations/google/api.py
@@ -39,7 +39,7 @@ class GoogleAPI:
         if search_result.get('status') != 'OK' or not search_result.get('results'):
             return {}
 
-        results = search_result['results'][:5]  # 若有多筆資料，僅取前五筆
+        results = search_result['results'][:10]  # 若有多筆資料，僅取前十筆
 
         shops = []
         for shop in results:
@@ -246,7 +246,7 @@ class GoogleAPI:
         # 根據加權評分進行排序
         sorted_places = sorted(weighted_rank, key=lambda x: x['weighted_rating'], reverse=True)
 
-        target_cafes = sorted_places[:5]
+        target_cafes = sorted_places[:10]
 
         shops = [
             {'place_id': shop['place_id'], 'rating': shop['original_rating'],

--- a/integrations/tests/test_google_api.py
+++ b/integrations/tests/test_google_api.py
@@ -55,14 +55,14 @@ class TestSearchCoffeeShops:
         assert result[0] == {'name': '星巴克', 'place_id': 'ChIJ001'}
         assert result[1] == {'name': '路易莎', 'place_id': 'ChIJ002'}
 
-    def test_max_five_results(self, mocker):
-        """最多回傳 5 筆結果"""
+    def test_max_ten_results(self, mocker):
+        """最多回傳 10 筆結果"""
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'status': 'OK',
             'results': [
                 {'name': f'咖啡店{i}', 'place_id': f'ChIJ{i:03d}'}
-                for i in range(8)
+                for i in range(12)
             ]
         }
         mock_response.raise_for_status = MagicMock()
@@ -70,7 +70,7 @@ class TestSearchCoffeeShops:
 
         result = GoogleAPI.search_coffee_shops('咖啡')
 
-        assert len(result) == 5
+        assert len(result) == 10
 
     def test_timeout(self, mocker):
         """請求逾時回傳空字典"""
@@ -351,14 +351,14 @@ class TestSearchNearbyCoffeeShops:
 
         assert result == []
 
-    def test_max_five_results(self, mocker):
-        """最多回傳 5 筆結果"""
+    def test_max_ten_results(self, mocker):
+        """最多回傳 10 筆結果"""
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'status': 'OK',
             'results': [
                 {'place_id': f'ChIJ{i:03d}', 'name': f'咖啡店{i}', 'rating': 4.0, 'user_ratings_total': 100}
-                for i in range(8)
+                for i in range(12)
             ]
         }
         mock_response.raise_for_status = MagicMock()
@@ -366,7 +366,7 @@ class TestSearchNearbyCoffeeShops:
 
         result = GoogleAPI.search_nearby_coffee_shops(lat=25.033, lng=121.564)
 
-        assert len(result) == 5
+        assert len(result) == 10
 
     def test_weighted_rating_sort_order(self, mocker):
         """驗證加權評分排序：高評分但少人評 vs 中評分但多人評"""

--- a/line_bot/builders/flex_builder.py
+++ b/line_bot/builders/flex_builder.py
@@ -983,6 +983,50 @@ class QuickReplyBuilder:
         )
 
     @staticmethod
+    def create_district_search_actions(search_type, keyword, next_offset, has_more=False):
+        """
+        工作友善 / 寵物搜尋結果後的快速回覆
+        - 固定顯示「重新搜尋」
+        - has_more=True 時額外顯示「下一頁」
+        """
+        # 重新搜尋對應的 postback
+        re_search_map = {
+            'district': f'action=menu&type={MenuAction.DISTRICT_SEARCH}',
+            'pet': f'action=menu&type={MenuAction.PET_SEARCH}',
+            'pet_friendly': f'action=menu&type={MenuAction.PET_FRIENDLY_SEARCH}',
+            'all_pet': 'action=all_pet_search',
+        }
+        re_search_data = re_search_map.get(search_type, f'action=menu&type={MenuAction.SEARCH_SHOP_NAME}')
+
+        items = [
+            QuickReplyItem(
+                action=PostbackAction(
+                    label='🔍 重新搜尋',
+                    data=re_search_data
+                )
+            )
+        ]
+
+        if has_more:
+            from urllib.parse import urlencode
+            next_data = urlencode({
+                'action': 'next_page',
+                'search_type': search_type,
+                'keyword': keyword,
+                'offset': next_offset,
+            })
+            items.append(
+                QuickReplyItem(
+                    action=PostbackAction(
+                        label='➡️ 下一頁',
+                        data=next_data
+                    )
+                )
+            )
+
+        return QuickReply(items=items)
+
+    @staticmethod
     def create_vote_options(attribute):
         """
         產生投票選項的 Quick Reply

--- a/line_bot/event_handlers.py
+++ b/line_bot/event_handlers.py
@@ -12,8 +12,6 @@ from linebot.v3.messaging import (
     MessagingApi,
     ReplyMessageRequest,
     TextMessage,
-    FlexMessage,
-    FlexContainer,
 )
 from linebot.v3.webhooks import (
     MessageEvent,
@@ -26,8 +24,8 @@ from linebot.v3.webhooks import (
 
 from integrations.google.api import GoogleAPI
 from line_bot.constants import UserState
-from line_bot.builders.flex_builder import LineMessageBuilder, QuickReplyBuilder, FlexMessageBuilder
-from line_bot.handlers.postback_actions import ACTION_HANDLERS
+from line_bot.builders.flex_builder import LineMessageBuilder, QuickReplyBuilder
+from line_bot.handlers.postback_actions import ACTION_HANDLERS, _reply_cafe_page
 from line_bot.handlers.helpers import reply_text
 from line_bot.services.search_cache import SearchHistoryService
 from line_bot.state import StateManager
@@ -70,7 +68,7 @@ def handle_message(event):
         # 使用者查詢單一咖啡店，回傳結果
         if state == UserState.WAITING_SHOP_NAME:
             # 1. 先查本地 DB
-            cached_cafes = Cafe.objects.filter(name__icontains=text)[:5]
+            cached_cafes = Cafe.objects.filter(name__icontains=text)[:10]
 
             if cached_cafes:
                 now = timezone.now()
@@ -119,117 +117,65 @@ def handle_message(event):
         # 使用者輸入行政區查詢工作友善咖啡
         elif state == UserState.WAITING_DISTRICT:
             district = text.strip()
-
-            cafes = Cafe.objects.filter(
+            cafes_qs = Cafe.objects.filter(
                 address__icontains=district,
-                limited_time__in=['maybe','no'],
-                has_socket__in=['yes', 'maybe']
-            ).order_by('-favorite_count', '-user_ratings_total')[:5]
-
-            if not cafes.exists():
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=event.reply_token,
-                        messages=[TextMessage(
-                            text=(
-                                f'找不到「{district}」不限時且有插座的咖啡店 😢\n\n'
-                                '目前 DB 資料有限，建議先用其他方式搜尋該區店家，累積資料後再試試看！'
-                            )
-                        )]
-                    )
-                )
-            else:
-                flex_messages = [
-                    FlexMessageBuilder.create_shop_flex_message(cafe.to_dict(), is_multiple=True)
-                    for cafe in cafes
-                ]
-                carousel = {'type': 'carousel', 'contents': flex_messages}
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=event.reply_token,
-                        messages=[FlexMessage(
-                            alt_text=f'{district} 工作友善咖啡',
-                            contents=FlexContainer.from_dict(carousel)
-                        )]
-                    )
-                )
-
+                limited_time__in=['maybe', 'no'],
+                has_socket__in=['yes', 'maybe'],
+            ).order_by('-favorite_count', '-user_ratings_total')
+            _reply_cafe_page(
+                line_bot_api, event.reply_token,
+                cafes_qs=cafes_qs,
+                offset=0,
+                search_type='district',
+                keyword=district,
+                empty_msg=(
+                    f'找不到「{district}」不限時且有插座的咖啡店 😢\n\n'
+                    '目前 DB 資料有限，建議先用其他方式搜尋該區店家，累積資料後再試試看！'
+                ),
+                alt_text=f'{district} 工作友善咖啡',
+            )
             StateManager.reset_state(user_id)
             return
 
         elif state == UserState.WAITING_PET_DISTRICT:
             district = text.strip()
-            cafes = Cafe.objects.filter(
+            cafes_qs = Cafe.objects.filter(
                 address__icontains=district,
                 has_pet='yes',
-            ).order_by('-favorite_count', '-user_ratings_total')[:5]
-
-            if not cafes.exists():
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=event.reply_token,
-                        messages=[TextMessage(
-                            text=(
-                                f'找不到「{district}」有貓貓狗狗的咖啡店 🐈\n\n'
-                                '目前 DB 資料有限，建議先用其他方式搜尋該區店家，累積資料後再試試看！'
-                            )
-                        )]
-                    )
-                )
-            else:
-                flex_messages = [
-                    FlexMessageBuilder.create_shop_flex_message(cafe.to_dict(), is_multiple=True)
-                    for cafe in cafes
-                ]
-                carousel = {'type': 'carousel', 'contents': flex_messages}
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=event.reply_token,
-                        messages=[FlexMessage(
-                            alt_text=f'{district} 有貓貓狗狗的咖啡廳',
-                            contents=FlexContainer.from_dict(carousel)
-                        )]
-                    )
-                )
-
+            ).order_by('-favorite_count', '-user_ratings_total')
+            _reply_cafe_page(
+                line_bot_api, event.reply_token,
+                cafes_qs=cafes_qs,
+                offset=0,
+                search_type='pet',
+                keyword=district,
+                empty_msg=(
+                    f'找不到「{district}」有貓貓狗狗的咖啡店 🐈\n\n'
+                    '目前 DB 資料有限，建議先用其他方式搜尋該區店家，累積資料後再試試看！'
+                ),
+                alt_text=f'{district} 有貓貓狗狗的咖啡廳',
+            )
             StateManager.reset_state(user_id)
             return
 
         elif state == UserState.WAITING_PET_FRIENDLY_DISTRICT:
             district = text.strip()
-            cafes = Cafe.objects.filter(
+            cafes_qs = Cafe.objects.filter(
                 address__icontains=district,
                 pet_friendly='yes',
-            ).order_by('-favorite_count', '-user_ratings_total')[:5]
-
-            if not cafes.exists():
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=event.reply_token,
-                        messages=[TextMessage(
-                            text=(
-                                f'找不到「{district}」寵物友善的咖啡店 🐕\n\n'
-                                '目前 DB 資料有限，建議先用其他方式搜尋該區店家，累積資料後再試試看！'
-                            )
-                        )]
-                    )
-                )
-            else:
-                flex_messages = [
-                    FlexMessageBuilder.create_shop_flex_message(cafe.to_dict(), is_multiple=True)
-                    for cafe in cafes
-                ]
-                carousel = {'type': 'carousel', 'contents': flex_messages}
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=event.reply_token,
-                        messages=[FlexMessage(
-                            alt_text=f'{district} 寵物友善咖啡廳',
-                            contents=FlexContainer.from_dict(carousel)
-                        )]
-                    )
-                )
-
+            ).order_by('-favorite_count', '-user_ratings_total')
+            _reply_cafe_page(
+                line_bot_api, event.reply_token,
+                cafes_qs=cafes_qs,
+                offset=0,
+                search_type='pet_friendly',
+                keyword=district,
+                empty_msg=(
+                    f'找不到「{district}」寵物友善的咖啡店 🐕\n\n'
+                    '目前 DB 資料有限，建議先用其他方式搜尋該區店家，累積資料後再試試看！'
+                ),
+                alt_text=f'{district} 寵物友善咖啡廳',
+            )
             StateManager.reset_state(user_id)
             return
 

--- a/line_bot/handlers/postback_actions.py
+++ b/line_bot/handlers/postback_actions.py
@@ -16,6 +16,49 @@ from users.views import FavoritesManager
 
 logger = logging.getLogger(__name__)
 
+PAGE_SIZE = 5
+
+
+def _reply_cafe_page(line_bot_api, reply_token, cafes_qs, offset, search_type, keyword, empty_msg, alt_text):
+    """
+    分頁輔助：從 queryset 取指定頁的資料並回覆 carousel + quick_reply。
+
+    Args:
+        cafes_qs: 已過濾 + 排序好的 QuerySet（不含 slice）
+        offset:   本頁起始位置
+        search_type: 'district' / 'pet' / 'pet_friendly' / 'all_pet'
+        keyword:  搜尋關鍵字（用於「下一頁」postback）
+        empty_msg: 無資料時的提示文字
+        alt_text: carousel alt text
+    """
+    cafes = list(cafes_qs[offset:offset + PAGE_SIZE + 1])
+    has_more = len(cafes) > PAGE_SIZE
+    cafes = cafes[:PAGE_SIZE]
+
+    if not cafes:
+        reply_text(line_bot_api, reply_token, empty_msg)
+        return
+
+    flex_messages = [
+        FlexMessageBuilder.create_shop_flex_message(cafe.to_dict(), is_multiple=True)
+        for cafe in cafes
+    ]
+    carousel = {'type': 'carousel', 'contents': flex_messages}
+
+    quick_reply = QuickReplyBuilder.create_district_search_actions(
+        search_type, keyword, offset + PAGE_SIZE, has_more
+    )
+
+    flex_msg = FlexMessage(
+        alt_text=alt_text,
+        contents=FlexContainer.from_dict(carousel),
+    )
+    flex_msg.quick_reply = quick_reply
+
+    line_bot_api.reply_message(
+        ReplyMessageRequest(reply_token=reply_token, messages=[flex_msg])
+    )
+
 
 def handle_favorite(line_bot_api, reply_token, user, params):
     """處理收藏動作"""
@@ -363,26 +406,69 @@ MENU_HANDLERS = {
 
 
 def handle_all_pet_search(line_bot_api, reply_token, user, params):
-    """查詢全部有貓貓狗狗的咖啡店（不限地區）"""
-    cafes = Cafe.objects.filter(has_pet='yes').order_by('-favorite_count', '-user_ratings_total')[:5]
+    """查詢全部有貓貓狗狗的咖啡店（不限地區），支援分頁"""
+    offset = int(params.get('offset', 0))
+    cafes_qs = Cafe.objects.filter(has_pet='yes').order_by('-favorite_count', '-user_ratings_total')
 
-    if not cafes.exists():
-        reply_text(line_bot_api, reply_token, '目前資料庫還沒有有貓貓狗狗的咖啡店資料 😢\n歡迎投票回報你知道的店家！')
+    _reply_cafe_page(
+        line_bot_api, reply_token,
+        cafes_qs=cafes_qs,
+        offset=offset,
+        search_type='all_pet',
+        keyword='',
+        empty_msg='目前資料庫還沒有有貓貓狗狗的咖啡店資料 😢\n歡迎投票回報你知道的店家！',
+        alt_text='有貓貓狗狗的咖啡廳',
+    )
+
+
+def handle_next_page(line_bot_api, reply_token, user, params):
+    """處理翻頁動作"""
+    search_type = params.get('search_type')
+    keyword = params.get('keyword', '')
+    offset = int(params.get('offset', 0))
+
+    search_configs = {
+        'district': {
+            'filter': dict(
+                address__icontains=keyword,
+                limited_time__in=['maybe', 'no'],
+                has_socket__in=['yes', 'maybe'],
+            ),
+            'empty_msg': f'「{keyword}」沒有更多工作友善咖啡店了 ☕️',
+            'alt_text': f'{keyword} 工作友善咖啡',
+        },
+        'pet': {
+            'filter': dict(address__icontains=keyword, has_pet='yes'),
+            'empty_msg': f'「{keyword}」沒有更多有貓貓狗狗的咖啡店了 🐈',
+            'alt_text': f'{keyword} 有貓貓狗狗的咖啡廳',
+        },
+        'pet_friendly': {
+            'filter': dict(address__icontains=keyword, pet_friendly='yes'),
+            'empty_msg': f'「{keyword}」沒有更多寵物友善的咖啡店了 🐕',
+            'alt_text': f'{keyword} 寵物友善咖啡廳',
+        },
+        'all_pet': {
+            'filter': dict(has_pet='yes'),
+            'empty_msg': '沒有更多有貓貓狗狗的咖啡店了 🐈',
+            'alt_text': '有貓貓狗狗的咖啡廳',
+        },
+    }
+
+    config = search_configs.get(search_type)
+    if not config:
+        logger.warning(f'Unknown search_type for next_page: {search_type}')
         return
 
-    flex_messages = [
-        FlexMessageBuilder.create_shop_flex_message(cafe.to_dict(), is_multiple=True)
-        for cafe in cafes
-    ]
-    carousel = {'type': 'carousel', 'contents': flex_messages}
-    line_bot_api.reply_message(
-        ReplyMessageRequest(
-            reply_token=reply_token,
-            messages=[FlexMessage(
-                alt_text='有貓貓狗狗的咖啡廳',
-                contents=FlexContainer.from_dict(carousel)
-            )]
-        )
+    cafes_qs = Cafe.objects.filter(**config['filter']).order_by('-favorite_count', '-user_ratings_total')
+
+    _reply_cafe_page(
+        line_bot_api, reply_token,
+        cafes_qs=cafes_qs,
+        offset=offset,
+        search_type=search_type,
+        keyword=keyword,
+        empty_msg=config['empty_msg'],
+        alt_text=config['alt_text'],
     )
 
 
@@ -407,4 +493,5 @@ ACTION_HANDLERS = {
     'vote_answer': handle_vote_answer,
     'menu': handle_menu,
     'all_pet_search': handle_all_pet_search,
+    'next_page': handle_next_page,
 }

--- a/line_bot/tests/test_postback_actions.py
+++ b/line_bot/tests/test_postback_actions.py
@@ -334,3 +334,107 @@ class TestMenuPetSearch:
         mock_state.assert_called_once_with(user.line_user_id, UserState.WAITING_PET_DISTRICT)
         call_args = mock_api.reply_message.call_args[0][0]
         assert call_args.messages[0].quick_reply is not None
+
+
+@pytest.mark.django_db
+class TestHandleNextPage:
+    """測試 handle_next_page"""
+
+    def _mock_flex(self):
+        return patch('line_bot.handlers.postback_actions.FlexMessageBuilder.create_shop_flex_message',
+                     return_value=MagicMock()), \
+               patch('line_bot.handlers.postback_actions.FlexContainer.from_dict', return_value=MagicMock()), \
+               patch('line_bot.handlers.postback_actions.FlexMessage', return_value=MagicMock()), \
+               patch('line_bot.handlers.postback_actions.ReplyMessageRequest', return_value=MagicMock())
+
+    def test_district_next_page_returns_results(self):
+        """search_type=district：回傳下一頁工作友善咖啡"""
+        from line_bot.handlers.postback_actions import handle_next_page
+        for _ in range(3):
+            CafeFactory(address='大安區信義路', limited_time='no', has_socket='yes')
+        user = MagicMock()
+        mock_api = MagicMock()
+
+        with patch('line_bot.handlers.postback_actions.FlexMessageBuilder.create_shop_flex_message',
+                   return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.FlexContainer.from_dict', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.FlexMessage', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.ReplyMessageRequest', return_value=MagicMock()):
+            handle_next_page(mock_api, 'test_token', user, {
+                'search_type': 'district', 'keyword': '大安區', 'offset': '0'
+            })
+
+        mock_api.reply_message.assert_called_once()
+
+    def test_unknown_search_type_does_not_reply(self):
+        """未知 search_type，不觸發任何回覆"""
+        from line_bot.handlers.postback_actions import handle_next_page
+        user = MagicMock()
+        mock_api = MagicMock()
+
+        handle_next_page(mock_api, 'test_token', user, {
+            'search_type': 'unknown', 'keyword': '大安區', 'offset': '0'
+        })
+
+        mock_api.reply_message.assert_not_called()
+
+    def test_empty_results_replies_empty_msg(self):
+        """無結果時，回覆提示文字"""
+        from line_bot.handlers.postback_actions import handle_next_page
+        user = MagicMock()
+        mock_api = MagicMock()
+
+        handle_next_page(mock_api, 'test_token', user, {
+            'search_type': 'all_pet', 'keyword': '', 'offset': '0'
+        })
+
+        mock_api.reply_message.assert_called_once()
+        call_args = mock_api.reply_message.call_args[0][0]
+        assert '貓貓狗狗' in call_args.messages[0].text
+
+
+@pytest.mark.django_db
+class TestReplyCafePage:
+    """測試 _reply_cafe_page 分頁邏輯"""
+
+    def test_has_more_includes_next_page_button(self):
+        """結果超過 PAGE_SIZE 時，quick_reply 包含「下一頁」"""
+        from line_bot.handlers.postback_actions import _reply_cafe_page, PAGE_SIZE
+        for _ in range(PAGE_SIZE + 1):
+            CafeFactory(has_pet='yes')
+        cafes_qs = __import__('cafe.models', fromlist=['Cafe']).Cafe.objects.filter(has_pet='yes')
+        mock_api = MagicMock()
+
+        flex_msg_mock = MagicMock()
+        with patch('line_bot.handlers.postback_actions.FlexMessageBuilder.create_shop_flex_message',
+                   return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.FlexContainer.from_dict', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.FlexMessage', return_value=flex_msg_mock), \
+             patch('line_bot.handlers.postback_actions.ReplyMessageRequest', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.QuickReplyBuilder.create_district_search_actions') as mock_qr:
+            mock_qr.return_value = MagicMock()
+            _reply_cafe_page(mock_api, 'token', cafes_qs, 0, 'all_pet', '', 'empty', 'alt')
+
+        mock_qr.assert_called_once()
+        _, _, _, has_more_arg = mock_qr.call_args[0]
+        assert has_more_arg is True
+
+    def test_no_more_pages_omits_next_button(self):
+        """結果不超過 PAGE_SIZE 時，has_more=False"""
+        from line_bot.handlers.postback_actions import _reply_cafe_page, PAGE_SIZE
+        for _ in range(PAGE_SIZE - 1):
+            CafeFactory(has_pet='yes')
+        cafes_qs = __import__('cafe.models', fromlist=['Cafe']).Cafe.objects.filter(has_pet='yes')
+        mock_api = MagicMock()
+
+        with patch('line_bot.handlers.postback_actions.FlexMessageBuilder.create_shop_flex_message',
+                   return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.FlexContainer.from_dict', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.FlexMessage', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.ReplyMessageRequest', return_value=MagicMock()), \
+             patch('line_bot.handlers.postback_actions.QuickReplyBuilder.create_district_search_actions') as mock_qr:
+            mock_qr.return_value = MagicMock()
+            _reply_cafe_page(mock_api, 'token', cafes_qs, 0, 'all_pet', '', 'empty', 'alt')
+
+        _, _, _, has_more_arg = mock_qr.call_args[0]
+        assert has_more_arg is False


### PR DESCRIPTION
## Summary

- 行政區/寵物/工作友善搜尋加入 DB offset 分頁（每頁 5 筆），結果超過 5 筆時 QuickReply 自動出現「➡️ 下一頁」按鈕
- 新增 `handle_next_page` handler（`action=next_page&search_type=...&keyword=...&offset=...`）
- 新增 `_reply_cafe_page` 分頁輔助函式，共用於初次查詢（event_handlers）與翻頁（postback_actions）
- 新增 `QuickReplyBuilder.create_district_search_actions`，顯示「🔍 重新搜尋」+ 可選「➡️ 下一頁」
- Google API 搜尋上限 `[:5]` → `[:10]`（店名、地址、附近三種搜尋都更新）
- 更新 Google API 相關測試反映新上限

## Test plan

- [ ] 在 DB 有超過 5 筆符合條件的情況下，QuickReply 出現「下一頁」按鈕
- [ ] 點擊「下一頁」後正確顯示第 2 頁資料
- [ ] 最後一頁只顯示「重新搜尋」，不出現「下一頁」
- [ ] 地址/位置/店名搜尋結果最多顯示 10 筆
- [ ] 所有測試通過（250 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)