### PR TITLE
fix: vote system,because of TTL lock and cause system broken

### DIFF
--- a/line_bot/event_handlers.py
+++ b/line_bot/event_handlers.py
@@ -262,14 +262,17 @@ def handle_postback(event):
             reply_text(line_bot_api, event.reply_token, '找不到會員資料，請重新操作')
             return
 
-        if not LockService.acquire(user_id, 'postback'):
-            logger.info(f'User {user_id} throttled, skip processing')
-            return
+        action = params.get('action')
+
+        # vote_answer 由 state machine 保護，不需要 lock（避免快速作答時被擋）
+        if action != 'vote_answer':
+            if not LockService.acquire(user_id, 'postback'):
+                logger.info(f'User {user_id} throttled, skip processing')
+                return
 
         # 顯示打字中動畫
         show_loading(line_bot_api, user_id)
 
-        action = params.get('action')
         handler_func = ACTION_HANDLERS.get(action)
 
         if handler_func:

--- a/line_bot/event_handlers.py
+++ b/line_bot/event_handlers.py
@@ -264,11 +264,13 @@ def handle_postback(event):
 
         action = params.get('action')
 
-        # vote_answer 由 state machine 保護，不需要 lock（避免快速作答時被擋）
-        if action != 'vote_answer':
-            if not LockService.acquire(user_id, 'postback'):
-                logger.info(f'User {user_id} throttled, skip processing')
-                return
+        # 使用獨立 lock key 避免不同動作互相阻擋（如 vote 阻擋 vote_answer）
+        # vote_answer 縮短 TTL 以提升快速作答體驗，同時防止重複點擊
+        lock_category = f'postback:{action}' if action == 'vote_answer' else 'postback'
+        lock_ttl = 1 if action == 'vote_answer' else 2
+        if not LockService.acquire(user_id, lock_category, ttl=lock_ttl):
+            logger.info(f'User {user_id} throttled, skip processing')
+            return
 
         # 顯示打字中動畫
         show_loading(line_bot_api, user_id)

--- a/line_bot/tests/test_event_handlers.py
+++ b/line_bot/tests/test_event_handlers.py
@@ -394,8 +394,8 @@ class TestHandlePostback:
 
         mock_line_bot_api.reply_message.assert_not_called()
 
-    def test_vote_answer_bypasses_lock_and_dispatches(self):
-        """vote_answer 不受 LockService 限制，仍正常分派給 handler"""
+    def test_vote_answer_uses_independent_lock_key(self):
+        """vote_answer 使用獨立的 lock key（postback:vote_answer），不與其他 postback 共用"""
         user = UserFactory()
         event = self._make_event(user.line_user_id, 'action=vote_answer&attr=socket&value=yes')
         mock_handler = MagicMock()
@@ -403,33 +403,32 @@ class TestHandlePostback:
         with (
             patch('line_bot.event_handlers.ApiClient'),
             patch('line_bot.event_handlers.MessagingApi') as mock_messaging_cls,
-            patch('line_bot.event_handlers.LockService.acquire', return_value=False),
-            patch('line_bot.event_handlers.show_loading') as mock_loading,
-            patch('line_bot.event_handlers.ACTION_HANDLERS', {'vote_answer': mock_handler}),
-        ):
-            mock_line_bot_api = MagicMock()
-            mock_messaging_cls.return_value = mock_line_bot_api
-            handle_postback(event)
-
-        mock_loading.assert_called_once()
-        mock_handler.assert_called_once()
-
-    def test_vote_answer_does_not_acquire_lock(self):
-        """vote_answer 不呼叫 LockService.acquire"""
-        user = UserFactory()
-        event = self._make_event(user.line_user_id, 'action=vote_answer&attr=socket&value=yes')
-
-        with (
-            patch('line_bot.event_handlers.ApiClient'),
-            patch('line_bot.event_handlers.MessagingApi') as mock_messaging_cls,
-            patch('line_bot.event_handlers.LockService.acquire') as mock_lock,
+            patch('line_bot.event_handlers.LockService.acquire', return_value=True) as mock_lock,
             patch('line_bot.event_handlers.show_loading'),
-            patch('line_bot.event_handlers.ACTION_HANDLERS', {'vote_answer': MagicMock()}),
+            patch('line_bot.event_handlers.ACTION_HANDLERS', {'vote_answer': mock_handler}),
         ):
             mock_messaging_cls.return_value = MagicMock()
             handle_postback(event)
 
-        mock_lock.assert_not_called()
+        mock_lock.assert_called_once_with(user.line_user_id, 'postback:vote_answer', ttl=1)
+        mock_handler.assert_called_once()
+
+    def test_non_vote_answer_uses_shared_lock_key(self):
+        """一般 postback action 使用共用的 lock key（postback），TTL 為 2 秒"""
+        user = UserFactory()
+        event = self._make_event(user.line_user_id, 'action=favorite&place_id=abc')
+
+        with (
+            patch('line_bot.event_handlers.ApiClient'),
+            patch('line_bot.event_handlers.MessagingApi') as mock_messaging_cls,
+            patch('line_bot.event_handlers.LockService.acquire', return_value=True) as mock_lock,
+            patch('line_bot.event_handlers.show_loading'),
+            patch('line_bot.event_handlers.ACTION_HANDLERS', {'favorite': MagicMock()}),
+        ):
+            mock_messaging_cls.return_value = MagicMock()
+            handle_postback(event)
+
+        mock_lock.assert_called_once_with(user.line_user_id, 'postback', ttl=2)
 
 
 @pytest.mark.django_db

--- a/line_bot/tests/test_event_handlers.py
+++ b/line_bot/tests/test_event_handlers.py
@@ -394,6 +394,43 @@ class TestHandlePostback:
 
         mock_line_bot_api.reply_message.assert_not_called()
 
+    def test_vote_answer_bypasses_lock_and_dispatches(self):
+        """vote_answer 不受 LockService 限制，仍正常分派給 handler"""
+        user = UserFactory()
+        event = self._make_event(user.line_user_id, 'action=vote_answer&attr=socket&value=yes')
+        mock_handler = MagicMock()
+
+        with (
+            patch('line_bot.event_handlers.ApiClient'),
+            patch('line_bot.event_handlers.MessagingApi') as mock_messaging_cls,
+            patch('line_bot.event_handlers.LockService.acquire', return_value=False),
+            patch('line_bot.event_handlers.show_loading') as mock_loading,
+            patch('line_bot.event_handlers.ACTION_HANDLERS', {'vote_answer': mock_handler}),
+        ):
+            mock_line_bot_api = MagicMock()
+            mock_messaging_cls.return_value = mock_line_bot_api
+            handle_postback(event)
+
+        mock_loading.assert_called_once()
+        mock_handler.assert_called_once()
+
+    def test_vote_answer_does_not_acquire_lock(self):
+        """vote_answer 不呼叫 LockService.acquire"""
+        user = UserFactory()
+        event = self._make_event(user.line_user_id, 'action=vote_answer&attr=socket&value=yes')
+
+        with (
+            patch('line_bot.event_handlers.ApiClient'),
+            patch('line_bot.event_handlers.MessagingApi') as mock_messaging_cls,
+            patch('line_bot.event_handlers.LockService.acquire') as mock_lock,
+            patch('line_bot.event_handlers.show_loading'),
+            patch('line_bot.event_handlers.ACTION_HANDLERS', {'vote_answer': MagicMock()}),
+        ):
+            mock_messaging_cls.return_value = MagicMock()
+            handle_postback(event)
+
+        mock_lock.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestHandleMessageDistrictSearch:


### PR DESCRIPTION
2026.4.23

原本在 postback_action 統一使用 lock，並設置 TTL=2 ，避免使用者過度點選
不過這樣的機制卻會造成使用者在評價咖啡店時產生使用體驗不佳

因此，若 action 為 vote_answer，並不會被 lock快取影響到

Gemini 建議
將 快取鎖分為 vote 與 非vote
為vote TTL改成 1，避免 race condition的情況發生（若都沒有TTL的話）